### PR TITLE
Check if docker daemon is up before pulling thug on backend

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -30,6 +30,13 @@ docker daemon > /var/log/docker-daemon.log 2>&1 &
 echo "Making sure that mongodb is listening on all interfaces"
 sed -i 's/^  bindIp: 127.0.0.1/  bindIp: 0.0.0.0/' /etc/mongod.conf
 
+
+while  [  ! -f /var/run/docker.pid ]
+  do
+     echo "Checking for docker pid file"
+     sleep 5
+  done
+
 echo "Pulling Thug ... this may take a while..."
 docker pull pdelsante/thug-dockerfile
 


### PR DESCRIPTION
Pulling thug would sometimes occur before the docker daemon is running. This fix waits until docker.pid file is found  
